### PR TITLE
Fix emoji search

### DIFF
--- a/index.js
+++ b/index.js
@@ -179,7 +179,8 @@ module.exports = {
 
             return resolve();
         }).then(() => {
-            return httpGet(`${LM_KEYWORDSEARCH}?keyword=${query}&type=${type}&page_size=${count}&page_index=${page}&countryCode=${country}`);
+            const encodedQuery = encodeURIComponent(query);
+            return httpGet(`${LM_KEYWORDSEARCH}?keyword=${encodedQuery}&type=${type}&page_size=${count}&page_index=${page}&countryCode=${country}`);
         }).then(data => {
             if (data.status == 200) {
                 return data.data.data_info;


### PR DESCRIPTION
Encodes the search query so emoji and other unicode characters get converted to the proper format for the LiveMe API.

Fixes #10 and https://github.com/thecoder75/liveme-tools/issues/97