### PR TITLE
Fix infinite search

### DIFF
--- a/index.js
+++ b/index.js
@@ -180,7 +180,7 @@ module.exports = {
             return resolve();
         }).then(() => {
             const encodedQuery = encodeURIComponent(query);
-            return httpGet(`${LM_KEYWORDSEARCH}?keyword=${encodedQuery}&type=${type}&page_size=${count}&page_index=${page}&countryCode=${country}`);
+            return httpGet(`${LM_KEYWORDSEARCH}?keyword=${encodedQuery}&type=${type}&pagesize=${count}&page=${page}&countryCode=${country}`);
         }).then(data => {
             if (data.status == 200) {
                 return data.data.data_info;


### PR DESCRIPTION
Fixes the API call for search page and pagesize.

Discovered this issue while testing the emoji fix, right now the search just loops if there's at least 10 results.

For instance user search `asdf` and it will loop the first 10 users constantly, same thing for a hashtag search.